### PR TITLE
Enable historical DAH flag.

### DIFF
--- a/PFH/history/countries/DAH - Dahomey.txt
+++ b/PFH/history/countries/DAH - Dahomey.txt
@@ -41,6 +41,11 @@ colonial_policy = no_colonies
 
 set_country_flag = animist_country
 
+govt_flag = {
+	government = absolute_monarchy
+	flag = theocracy
+}
+
 ruling_party = DAH_conservative
 upper_house = {
 	fascist = 0


### PR DESCRIPTION
Part of the unused flag work (#4).

Use the historical flag (featuring a hand-drawn elephant) for an
absolute monarchy. This is the flag used in EU4 and most often seen on
websites dealing in history/vexillology.

This changes to the current monarchy flag (featuring an engraving-style
elephant) for a semi-constitutional or constitutional monarchy. (This
flag is possibly a more fanciful recreation of the historical one.)

There is literally no good reason to do this other than:

- it's kinda funny to see a drawing turn into an engraving after
  Westernisation and liberalisation
- I will do anything to add more elephant flags to the game