### PR TITLE
Make the Witwatersand Gold Rush less annoying.

### DIFF
--- a/PFH/events/BoerWar.txt
+++ b/PFH/events/BoerWar.txt
@@ -1446,7 +1446,10 @@ country_event = {
 	
 	trigger = {
 		is_greater_power = yes
-		NOT = { has_country_flag = boer_accepted }
+		NOT = {
+			has_country_flag = boer_accepted
+			has_country_flag = turned_down_the_witwatersrand_gold_rush
+		}
 		any_neighbor_country = {
 			OR = {
 				has_country_modifier = witwatersrand_gold_rush
@@ -1455,8 +1458,18 @@ country_event = {
 					2106 = { trade_goods = precious_metal }
 				}
 			}
-			part_of_sphere = no
+			NOT = {
+				vassal_of = THIS
+				in_sphere = THIS
+				war_with = THIS
+			}
 			is_greater_power = no
+			OR = {
+				part_of_sphere = no
+				sphere_owner = {
+					NOT = { war_with = THIS }
+				}
+			}
 		}
 	}
 	
@@ -1466,8 +1479,9 @@ country_event = {
 	
 	option = {
 		name = "EVT98235OPTA"
-		random_country = {
+		any_country = {
 			limit = {
+				exists = yes
 				OR = {
 					has_country_modifier = witwatersrand_gold_rush
 					AND = {
@@ -1475,8 +1489,12 @@ country_event = {
 						2106 = { trade_goods = precious_metal }
 					}
 				}
+				NOT = {
+					vassal_of = THIS
+					in_sphere = THIS
+					war_with = THIS
+				}
 				is_greater_power = no
-				is_vassal = no
 				part_of_sphere = no
 			}
 			add_casus_belli = {
@@ -1486,8 +1504,9 @@ country_event = {
 			}
 		}
 		
-		random_country = {
+		any_country = {
 			limit = {
+				exists = yes
 				OR = {
 					has_country_modifier = witwatersrand_gold_rush
 					AND = {
@@ -1495,8 +1514,12 @@ country_event = {
 						2106 = { trade_goods = precious_metal }
 					}
 				}
+				NOT = {
+					vassal_of = THIS
+					in_sphere = THIS
+					war_with = THIS
+				}
 				is_greater_power = no
-				is_vassal = no
 				part_of_sphere = yes
 			}
 			sphere_owner = {
@@ -1508,13 +1531,22 @@ country_event = {
 			}
 		}
 		
-		random_country = {
+		any_country = {
 			limit = { has_country_modifier = witwatersrand_gold_rush }
 			relation = {
 				who = THIS
 				value = -100
 			}
 			remove_country_modifier = witwatersrand_gold_rush
+		}
+	}
+
+	option = {
+		name = "EVT98235OPTB"
+		set_country_flag = turned_down_the_witwatersrand_gold_rush
+
+		ai_chance = {
+			factor = 0
 		}
 	}
 }

--- a/PFH/localisation/00_HPM_events.csv
+++ b/PFH/localisation/00_HPM_events.csv
@@ -3013,6 +3013,7 @@ EVTDESC98235;Migrants have been moving in large numbers through our African colo
 EVTNAME98236;Kimberley Gold Rush;;;;;;;;;;;;x,,,,,,,,,,,,,,,,,,,,,,
 EVTDESC98236;Gold has been discovered in the Kimberley province, leading to claims from both the Transvaal and Oranje governments that the region rightfully belongs to them. Mediation by the colonial government has led to Kimberley being awarded to the griquas -- who have subsequently consented to annexation by $COUNTRY$. This has led to considerable bad blood between the Boer and $COUNTRY_ADJ$ governments.;;;;;;;;;;;;x,,,,,,,,,,,,,,,,,,,,,
 EVT98235OPTA;They are proving to be a nuisance.;;;;;;;;;;;;x,,,,,,,,,,,,,,,,,,,,,
+EVT98235OPTB;Never bother me with this again.;;;;;;;;;;;;x,,,,,,,,,,,,,,,,,,,,,
 EVTNAME98240;The South African Union ;;;;;;;;;;;;x,,,,,,,,,,,,,,,,,,,,,,
 EVTDESC98240;The time has come to consider joining the South African union.;;;;;;;;;;;;x,,,,,,,,,,,,,,,,,,,,,,
 EVT98240OPTA;This is for the best.;;;;;;;;;;;;x,,,,,,,,,,,,,,,,,,,,,,

--- a/README.markdown
+++ b/README.markdown
@@ -20,6 +20,12 @@ few flag tweaks as well the following:
 0.1.1-dev (in development)
 --------------------------
 
+Based on [HFM 1.27F Beta].
+
+### Tweaks
+
+- Reduce the amount of notifications from the Witwatersrand Gold Rush ([#1]).
+
 ### Bugfixes
 
 - An uncivilized country can only lose one port per unequal treaty they've been forced to sign.


### PR DESCRIPTION
If a human player ever had the unfortunate luck of bordering the
Witwatersand Gold Rush province, they were beset by regular event
notifications (~2 per year). This curtails the number of notifications
somewhat, while also adding an option for human players to never be
notified again.

This does not change the MTTH so as to not affect the promptness of the
2nd Boer War firing.