### PR TITLE
Rbx4/restore democracy sa

### DIFF
--- a/PFH/decisions/FlavourMod_GreatPowers.txt
+++ b/PFH/decisions/FlavourMod_GreatPowers.txt
@@ -75,6 +75,7 @@ political_decisions = {
 		allow = {
 			any_neighbor_country = { 
 				government = proletarian_dictatorship 	
+				capital_scope = { continent = south_america }
 				is_vassal = no
 				NOT = { truce_with = THIS }
 			}


### PR DESCRIPTION
The intent of this branch is to prevent the ai from spamming the Restore Democracy in South America decision when certain nations, especially Costa Rica, go communist. 

This decision occurs in FlavourMod_GreatPowers.txt in `restore_republic_south_america`  The `allow` statement needed to be equalized with the `effect` statement to permit use of the decision only when it can work, using `capital_scope = { continent = south_america }`

The fix seems to be working, because the spam has ceased and Brazil will attack Paraguay whenever it goes communist.