### PR TITLE
Rbx4/aden protectorate

### DIFF
--- a/PFH/decisions/ENG.txt
+++ b/PFH/decisions/ENG.txt
@@ -528,16 +528,18 @@ political_decisions = {
 		
 		allow = {
 			war = no
-			OR = {
-				LHJ = { exists = no }
-				owns = 1412
+			1412 = { 
+				OR = {
+					owned_by = THIS
+					owner = { in_sphere = THIS }
+					owner = { vassal_of = THIS }
+				}
 			}
 			1173 = {
 				OR = {
 					owned_by = THIS
 					owner = { in_sphere = THIS }
 					owner = { vassal_of = THIS }
-					KTH = { exists = no }
 				}
 			}
 			1175 = {
@@ -545,7 +547,6 @@ political_decisions = {
 					owned_by = THIS
 					owner = { in_sphere = THIS }
 					owner = { vassal_of = THIS }
-					MHR = { exists = no }
 				}
 			}
 			1176 = {
@@ -553,7 +554,6 @@ political_decisions = {
 					owned_by = THIS
 					owner = { in_sphere = THIS }
 					owner = { vassal_of = THIS }
-					FDL = { exists = no }
 				}
 			}
 			1177 = {
@@ -561,7 +561,6 @@ political_decisions = {
 					owned_by = THIS
 					owner = { in_sphere = THIS }
 					owner = { vassal_of = THIS }
-					MHR = { exists = no }
 				}
 			}
 			YEM = { exists = no }
@@ -598,11 +597,10 @@ political_decisions = {
 			diplomatic_influence = { who = YEM value = 400 }
 			relation = { who = YEM value = 400 }
 			YEM = {
-				capital = 1176
+				capital = 1412
 				money = 10000
 				research_points = 6000
 				government = absolute_monarchy
-				1412 = { secede_province = THIS }
 				tech_school = unciv_tech_school
 			}
 			random_owned = {


### PR DESCRIPTION
Here is the Aden Protectorate code. After several tests it looks fine. [The issue here](https://github.com/moretrim/PFH/issues/36) references the playtesting process and code in greater detail.

This was explicitly designed to prevent the UK stealing Aden through decision after the player takes it, when the UK later takes another southern Yemeni state. In the playthrough that inspired this, I had taken all Yemeni states except one, and then the UK took that one and pushed their decision to steal Aden.
