### PR TITLE
Rbx4/ryukyu puppetry

### DIFF
--- a/PFH/decisions/Japan.txt
+++ b/PFH/decisions/Japan.txt
@@ -535,7 +535,6 @@ political_decisions = {
 			government = prussian_constitutionalism
 			any_pop = { militancy = -2 }
 			
-			create_vassal = RYU
 		}
 		
 		ai_will_do = { factor = 1 }

--- a/PFH/events/JAPFlavor.txt
+++ b/PFH/events/JAPFlavor.txt
@@ -1411,7 +1411,6 @@ country_event = {
 			}
 			inherit = THIS
 		}
-		create_vassal = RYU
 	}
 }
 
@@ -1749,7 +1748,6 @@ country_event = {
 			end_war = THIS
 			country_event = 97652
 		}
-		create_vassal = RYU
 	}
 }
 


### PR DESCRIPTION
When Japan westernizes with the occasional Choshu victory and undergoes the Meiji Restoration event `97646` Ryukyu becomes a puppet of a non-existent Choshu, which appears to be a scope bug. 

Also another vassalization of Ryukyu occurs in the `meiji_constitution` decision. While it is most likely intended for Ryukyu to become a satellite of westernized Japan, I also removed this from the Meiji Restoration event, the Tokugawa Victory event, and the Meiji Constitution decision, because I could not find a reason to enforce this. Most especially, Ryukyu was under dual influence by Japan and China until 1874, further resisting removal of sovereignty until 1879.

For historical accuracy, it seemed best to rely upon the Ryukyu annexation decision instead of enforcing puppetry here: The `inherit_ryukyu` decision is a more elegant way of expressing the situation. This also forces Japan to earn their conquest of Ryukyu through usually sphering it, instead of automatically acquiring it.

I have left in the stipulation in `inherit_ryukyu` that prevents the ai from clicking it when when the player is Ryukyu. This means that Ryukyu should be a bit easier to play (no automatic puppetry). Additionally, it should be easier for the player to acquire Ryukyu, during the time window before ai Japan can annex it.

Pictorially, here is the original problem, with Ryukyu as a satellite of a non-existant Choshu:
 ![RyukyuPuppetry](https://user-images.githubusercontent.com/17787203/69486746-befa8000-0e03-11ea-863f-84520a735929.png)

 With the changes, this no longer happens, and ai Japan annexes ai Ryukyu quickly at any rate, after readily sphering them:
 ![RyukyuPuppetry](https://user-images.githubusercontent.com/17787203/69489570-ea469480-0e2e-11ea-8bdb-91526397b760.png)

 After sphering (ai only):
![RyukyuPuppetry](https://user-images.githubusercontent.com/17787203/69489602-b324b300-0e2f-11ea-905c-10290038e549.png)

Ryukyu is no longer automatically puppeted by the Meiji Constitution event. Instead, the other path is preserved where Ryukyu can eventually be annexed through the unchanged `inherit_ryukyu` event. The second commit was added (if I remember the timeline correctly) because I had missed a part of code where Ryukyu was automatically puppeted, this time after a Shogunate victory.