### PR TITLE
Rbx4/france dismantlement

### DIFF
--- a/PFH/events/GreatWar_Events.txt
+++ b/PFH/events/GreatWar_Events.txt
@@ -5853,6 +5853,7 @@ country_event = {
 				is_colonial = no
 				}
 			secede_province = GUY
+			remove_core = FRA
 		}
 	}
 }

--- a/PFH/events/GreatWar_Events.txt
+++ b/PFH/events/GreatWar_Events.txt
@@ -5713,6 +5713,23 @@ country_event = {
 			}
 			country_event = 96092
 		}
+
+		#rbx note - remove France cores from Algerian and Guyanan colonies before giving colonies to GP's
+		any_owned = {
+			limit = {
+				is_core = ALD
+				is_colonial = yes
+				}
+			remove_core = FRA
+		}
+
+		any_owned = {
+			limit = {
+				is_core = GUY
+				is_colonial = yes
+				}
+			remove_core = FRA
+		}
 		
 		#give colonies without cores to truce GP's
 		random_owned = {
@@ -5837,6 +5854,7 @@ country_event = {
 		}
 
 		#rbx release Algeria if owned and take away French cores
+
 		any_owned = {
 			limit = {
 				is_core = ALD

--- a/PFH/events/GreatWar_Events.txt
+++ b/PFH/events/GreatWar_Events.txt
@@ -4360,7 +4360,7 @@ country_event = {
 			country_event = 96018
 		}
 
-		#If California does not exist, release it as an ally (with Oregon} 
+		#If California does not exist, release it as an ally (with Oregon)
 		any_country = {
 			limit = {
 				tag = CAL
@@ -5621,7 +5621,7 @@ country_event = {
 				}
 			}
 			relation = { who = THIS value = 200 }
-		}	
+		}
 
 		#release all cores to anyone with a truce
 		any_country = {
@@ -5712,23 +5712,6 @@ country_event = {
 				NOT = { tag = BOR }
 			}
 			country_event = 96092
-		}
-
-		#rbx note - remove France cores from Algerian and Guyanan colonies before giving colonies to GP's
-		any_owned = {
-			limit = {
-				is_core = ALD
-				is_colonial = yes
-				}
-			remove_core = FRA
-		}
-
-		any_owned = {
-			limit = {
-				is_core = GUY
-				is_colonial = yes
-				}
-			remove_core = FRA
 		}
 		
 		#give colonies without cores to truce GP's
@@ -5858,20 +5841,27 @@ country_event = {
 		any_owned = {
 			limit = {
 				is_core = ALD
+				is_colonial = yes
+			}
+			remove_core = THIS
+		}
+
+		any_owned = {
+			limit = {
+				is_core = ALD
 				is_colonial = no
-				}
+			}
+			remove_core = THIS
 			secede_province = ALD
-			remove_core = FRA
 		}
 
 		#rbx release French Guiana if owned and a state
 		any_owned = {
 			limit = {
 				is_core = GUY
-				is_colonial = no
-				}
+			}
+			remove_core = THIS
 			secede_province = GUY
-			remove_core = FRA
 		}
 	}
 }

--- a/PFH/events/GreatWar_Events.txt
+++ b/PFH/events/GreatWar_Events.txt
@@ -5835,6 +5835,27 @@ country_event = {
 			name = no_more_war
 			duration = 3650
 		}
+
+		#rbx release Algeria if owned and take away French cores
+		any_owned = {
+			limit = {
+				is_core = ALD
+				is_colonial = no
+				}
+			}
+			secede_province = ALD
+			remove_core = FRA
+		}
+
+		#rbx release French Guiana if owned and a state
+		any_owned = {
+			limit = {
+				is_core = GUY
+				is_colonial = no
+				}
+			}
+			secede_province = GUY
+		}
 	}
 }
 

--- a/PFH/events/GreatWar_Events.txt
+++ b/PFH/events/GreatWar_Events.txt
@@ -5842,7 +5842,6 @@ country_event = {
 				is_core = ALD
 				is_colonial = no
 				}
-			}
 			secede_province = ALD
 			remove_core = FRA
 		}
@@ -5853,7 +5852,6 @@ country_event = {
 				is_core = GUY
 				is_colonial = no
 				}
-			}
 			secede_province = GUY
 		}
 	}


### PR DESCRIPTION
(https://github.com/moretrim/PFH/commit/138d51220c2105306aec177e7fae461b22815353)
In default HFM, overseas departments such as Algeria and French Guiana go unchanged when France is dismantled. This new change releases state provinces in Algeria and French Guiana when France is dismantled, because it did not make sense for a dismantled France to continue to possess overseas states and cores when other nations do not. Colonial provinces are not given to these tags, but like other colonies are instead given to the dismantlement war victors.

(https://github.com/moretrim/PFH/commit/0d031c60f19e1b4015a82f4ead4889c0d14bda49)
I believe this was a relatively minor fix to my own code in the previous commit, to balance brackets.

(https://github.com/moretrim/PFH/commit/25a0ee4c25ae60610c1e35a69cd249ad38c28852)
I did not even know until this time that France gets cores on Algeria and Guyana. These will now be removed after dismantlement. While France also retains cores on its Indian Ocean territories, I did not remove these. These may be tackled on another branch later.

With this change, the results look like this:
![FranceDismantlement](https://user-images.githubusercontent.com/17787203/63825744-c1d2fb00-c910-11e9-89a6-056f8c85e8de.png)

(https://github.com/moretrim/PFH/commit/e85a0f93706306d2daf3a8c681adb020b3f94449)
I discovered that the previous commits all did not always work as intended because they required `remove_core = THIS` instead of `remove_core = FRA`. Therefore, I changed the event accordingly. This was required because France is not only `FRA` but can instead be `BOR` or `VIC`.

During lengthy troubleshooting, I discovered that a `}` was used in a comment in the USA section, indicating a bracket imbalance that probably did not impact anything, but I changed it to a `)` anyway.