### PR TITLE
Rbx4/heavenly kingdom

### DIFF
--- a/PFH/events/China.txt
+++ b/PFH/events/China.txt
@@ -28,11 +28,19 @@ country_event = {
 			owner = { activate_technology = experimental_railroad  clr_country_flag = activate_experimental_railroad }
 		}
 		remove_country_modifier = missionary_activity
-		religion = mahayana
-		set_country_flag = mahayana_country
-		clr_country_flag = protestant_country
-		clr_country_flag = change_to_protestant
 		clr_country_flag = missionary_activity
+		QNG = {
+			clr_country_flag = protestant_country
+			clr_country_flag = change_to_protestant
+		}
+		CHI = {
+			clr_country_flag = protestant_country
+			clr_country_flag = change_to_protestant
+		}
+		TPG = {
+			set_country_flag = protestant_country
+			set_country_flag = change_to_protestant
+		}
 		MCK = { all_core = { add_core = CHI } }
 		XBI = { all_core = { add_core = CHI } }
 		XIN = { all_core = { add_core = CHI } }


### PR DESCRIPTION
(https://github.com/moretrim/PFH/commit/1fb253bfd307c9a8ff4149dd3512ae0494199a0b)

These changes were made because it was noticed that Heavenly Kingdom arbitrarily switches from Protestant to Mahayana upon westernization. This appears to have been a bug, and for the first commit I made some simple changes to keep it Protestant.

(https://github.com/moretrim/PFH/commit/3d2b52008fcf94604d2e40f328dfbb52252da9bf)
After discussion and further investigation, this was changed so that there is no longer a new religion specification for the main Chinese tags when they westernize in event `90900`. It did not seem necessary since the tags already had a state religion before westernization. Additionally, it seemed best to keep the `protestant_country` and `change_to_protestant` country flags, because they are occasionally used by civilized tags.

In playtesting, I have guessed that pops will tend to be converted to the state religion if no other relevant flags are present. Here before westernization, pops in Heavenly Kingdom convert to Protestant as expected:
![HeavenlyKingdom](https://user-images.githubusercontent.com/17787203/69500522-d479b380-0eb0-11ea-9e96-905db6221d61.png)

After westernization, the conversion is still working:
![HeavenlyKingdom](https://user-images.githubusercontent.com/17787203/69500548-0ab73300-0eb1-11ea-91b4-41b32f8f4d08.png)

To see if the removal of specification of religion from the other tags (Qing Empire and Beiyang), I checked to see if conversion to Mahayana works as expected. Before westernization:
![HeavenlyKingdom](https://user-images.githubusercontent.com/17787203/69500616-7b5e4f80-0eb1-11ea-83b9-f3ef6379cb1c.png)

After westernization it is still working:
![HeavenlyKingdom](https://user-images.githubusercontent.com/17787203/69500644-b2346580-0eb1-11ea-8fd6-716e71255d27.png)