### PR TITLE
Occupation of the Congo now with proper tech requirements, no longer …

### DIFF
--- a/PFH/decisions/FlavourMod_Africa.txt
+++ b/PFH/decisions/FlavourMod_Africa.txt
@@ -658,9 +658,9 @@ political_decisions = {
 		allow = {
 			NOT = { any_greater_power = { war_with = THIS } }
 			NOT = { has_global_flag = congo_failed }
-			invention = colonial_negotiations
 			OR = {
 				AND = {
+					invention = colonial_negotiations
 					owns = 1972
 					1976 = { empty = yes } #Gabon
 				}
@@ -669,11 +669,13 @@ political_decisions = {
 						has_global_flag = called_congo_conference
 						1962 = { empty = no }
 					}
-					owns = 1977 
+					invention = colonial_negotiations
+					owns = 1977
 					1976 = { empty = no } #Gabon
 					1980 = { empty = yes } #Congo
 				}
 				AND = {
+					invention = the_dark_continent
 					owns = 1981
 					1966 = { empty = yes } #Ubangi-Shari
 				}	
@@ -703,11 +705,11 @@ political_decisions = {
 			random_owned = {
 				limit = {
 					owner = {
-						owns = 1977	
+						owns = 1977
 						1976 = { empty = no } #Gabon
 						1980 = { empty = yes } #Congo
 						invention = colonial_negotiations
-						OR = { 
+						OR = {
 							has_global_flag = called_congo_conference
 							1962 = { empty = no }
 						}


### PR DESCRIPTION
…spammed by ai, and no longer enabled when the effect cannot do anything

See issue: [https://github.com/moretrim/PFH/issues/26](url) for more discussion as well.

Commit: Initial fix was largely reverted, in favor of what is listed below.

Commit: New fix that allows the decision to be used iteratively but not be spammed by the ai.

Determined that this decision is actually supposed to be spammed to "step up" from Gabon through Chad to occupy the Congo Basin. It was being spammed by the ai (and blocked other ai decisions) up until the invention of The Dark Continent. Therefore, changed it to require that invention before it would be enabled.

Commit: Fixing tech requirements to stop ai spam, other minor changes, fixing previous errors, and modernization of my work on this decision.

The `occupation_of_the_congo` decision is updated with proper cultural tech requirements for each iterative stage of the occupation. This fixes a problem where the decision would be active but ineffective until `the_dark_continent` was discovered, which had made the decision visible until then for nations that had the other requirements. The ai would also spam the decision until the effect could do something, at least slowing down the game. Some minor fixes were made to remove two whitespace errors, a potential encoding issue, and some ineffective lines in the `allow` statement. Requirements for the proper techs were added into each part of the `allow`, which already were required in their respective parts of the `effect`. While it arguably makes sense to only require `colonial_negotiations` for the whole decision, I think the difference only comes into play after a nation would already have it.

The problem looked like this:

![CongoOccupation](https://user-images.githubusercontent.com/17787203/75637182-968bda00-5bd9-11ea-8764-2f77159272a2.png)

and fixed by this and previous commits, it looks like this:

![CongoOccupation](https://user-images.githubusercontent.com/17787203/75640673-b37cd900-5bea-11ea-9202-0a75403d760a.png)

It was also tested for post-1880, pre-1890 functionality, and it seems to be fine:

![CongoOccupation](https://user-images.githubusercontent.com/17787203/75954165-e97ac100-5e67-11ea-94e3-70158f4f0559.png)

and:

![CongoOccupation](https://user-images.githubusercontent.com/17787203/75954188-f5668300-5e67-11ea-89f2-e3ce305a0706.png)

Post-1890 it seems good as well: 

![CongoOccupation](https://user-images.githubusercontent.com/17787203/76026583-e9200b80-5ee3-11ea-9ab4-36da9397035e.png)

Line endings were converted to CR LF by the Windows version of git, and therefore needed to be changed to LF. Text encoding enforced as Windows-1252.